### PR TITLE
Add reindex command for FHIR server

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -87,6 +87,8 @@ pub enum CliCommand {
         /// Version to update to (default: latest)
         version: Option<String>,
     },
+    /// Trigger a reindex of all resources on the FHIR server
+    Reindex,
 }
 
 #[derive(Parser, Debug, Clone)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,6 +3,9 @@ mod capability_statement;
 mod codeable_concept;
 mod coding;
 pub mod operation_outcome;
+mod parameters;
+
+pub use parameters::Parameters;
 
 use anyhow::{anyhow, Context};
 use bundle::Bundle;
@@ -146,6 +149,24 @@ impl FhirClient {
             .error_for_status()?
             .json()
             .await?)
+    }
+
+    pub async fn start_reindex(&self) -> Result<Parameters, FhirError> {
+        let body = serde_json::json!({ "resourceType": "Parameters" });
+        let response = self
+            .request(Method::POST, "/$reindex")
+            .json(&body)
+            .send()
+            .await?;
+        Ok(handle_response_error(response).await?.json().await?)
+    }
+
+    pub async fn get_reindex_status(&self, id: &str) -> Result<Parameters, FhirError> {
+        let response = self
+            .request(Method::GET, &format!("/reindex/{id}"))
+            .send()
+            .await?;
+        Ok(handle_response_error(response).await?.json().await?)
     }
 }
 

--- a/src/client/parameters.rs
+++ b/src/client/parameters.rs
@@ -1,0 +1,22 @@
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct Parameters {
+    pub parameter: Vec<Parameter>,
+}
+
+#[derive(Deserialize)]
+pub struct Parameter {
+    pub name: String,
+    #[serde(rename = "valueString")]
+    pub value_string: String,
+}
+
+impl Parameters {
+    pub fn get_value(&self, name: &str) -> Option<&str> {
+        self.parameter
+            .iter()
+            .find(|p| p.name == name)
+            .map(|p| p.value_string.as_str())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,10 @@ async fn run(args: Args) -> anyhow::Result<()> {
         }
         CliCommand::GenerateCompletions(cmd) => subcommands::generate_completions(cmd),
         CliCommand::Update { version } => subcommands::update(version).await,
+        CliCommand::Reindex => {
+            let client = get_client(&config, &args).await?;
+            subcommands::reindex(client).await
+        }
     }
 }
 

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -405,3 +405,36 @@ pub async fn update(version: Option<String>) -> anyhow::Result<()> {
 
     Ok(())
 }
+
+pub async fn reindex(client: FhirClient) -> anyhow::Result<()> {
+    let bar = ProgressBar::new_spinner().with_message("Starting reindex");
+    bar.enable_steady_tick(Duration::from_millis(100));
+
+    let result = client.start_reindex().await?;
+    let id = result
+        .get_value("id")
+        .ok_or_else(|| anyhow::anyhow!("Reindex response missing 'id' parameter"))?
+        .to_owned();
+
+    bar.set_message(format!("Reindex started (id: {id}), waiting for completion..."));
+
+    loop {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let status_result = client.get_reindex_status(&id).await?;
+        let status = status_result
+            .get_value("status")
+            .ok_or_else(|| anyhow::anyhow!("Reindex status response missing 'status' parameter"))?
+            .to_owned();
+
+        if status == "completed" {
+            bar.finish_and_clear();
+            println!("Reindex {} completed successfully", style(id).bold());
+            return Ok(());
+        }
+
+        bar.set_message(format!(
+            "Reindex in progress (id: {id}), status: {status}..."
+        ));
+    }
+}


### PR DESCRIPTION
Introduce a command to trigger reindexing of all resources on the FHIR server, along with functionality to start the reindex process and check its status. This enhancement improves the client’s capabilities for managing resource indexing.